### PR TITLE
Patch nn.TransformerEncoder into HF

### DIFF
--- a/examples/pytorch/benchmarking/benchmark_bettertransformer.py
+++ b/examples/pytorch/benchmarking/benchmark_bettertransformer.py
@@ -1,0 +1,88 @@
+import torch
+
+def numerical_test(tensors1, tensors2, rtol, atol):
+    """
+    truth_tensors is the source of truth.
+    test_dict looks like
+    [
+        (name, out_tensors, atol, rtol),
+        ...
+    ]
+    """
+    assert len(tensors1) == len(tensors2)
+    n_failures = 0
+    max_diff = 0
+    for tensor1, tensor2 in zip(tensors1, tensors2):
+        max_diff = max(max_diff, torch.max(torch.abs(tensor1 - tensor2)))
+        if not torch.allclose(tensor1, tensor2, atol=atol, rtol=rtol):
+            n_failures += 1
+
+    if n_failures == 0:
+        print(f"Numerical test PASS")
+    else:
+        print(f"Numerical test FAIL {n_failures}/{len(tensors1)}. Max diff is {max_diff}")
+
+def benchmark_torch_function(is_cuda, f, inputs):
+    """
+    Benchmark torch on gpu or cpu
+    """
+    iters = len(inputs)
+    if(is_cuda):
+        f(inputs[0])
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+        for x in inputs:
+            f(x)
+        end_event.record()
+        torch.cuda.synchronize()
+        return (start_event.elapsed_time(end_event) * 1.0e-3) / iters
+    else:
+        import time
+
+        f(inputs[0])
+        start_event = time.perf_counter()
+        for x in inputs:
+            f(x)
+        end_event = time.perf_counter()
+        return (end_event - start_event) / iters
+
+def get_outputs(f, inputs):
+    outputs = [f(x).logits for x in inputs]
+    return outputs
+
+
+def benchmark():
+    from transformers import AutoModelForSequenceClassification
+    
+    num_batches = 500
+    batch_size = 1
+    seqlen = 25
+    is_cuda = True # TODO CPU + half does not work. fp32 option?
+    device = 'cuda' if is_cuda else 'cpu' 
+
+    model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased").eval().to(device).half()
+
+     # batch size 1, seqlen 25
+    eval_inputs = torch.randint(low=1, high=25000, size=(num_batches, batch_size, seqlen)).to(device)
+
+    with torch.no_grad():
+        hf_t = benchmark_torch_function(is_cuda, model, eval_inputs)
+        out = get_outputs(model, eval_inputs)
+    print(f"HF time per batch {hf_t}")
+
+    # right now, need to set all these again because the new module doesn't automatically configure itself
+    model.bert.encoder = model.bert.encoder.to_fast()
+    model = model.eval().to(device).half()
+
+    with torch.no_grad():
+        bt_t = benchmark_torch_function(is_cuda, model, eval_inputs)
+        out2 = get_outputs(model, eval_inputs)
+    print(f"BT time per batch {bt_t}")
+
+    numerical_test(out, out2, 0, 1e-2) # absolute difference of 1 percent
+
+if __name__=="__main__":
+    benchmark()
+    

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -650,8 +650,13 @@ class BertFastEncoder(nn.Module):
         if attention_mask is not None:
             attention_mask = ~attention_mask.bool()
             attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
-            # remove padding from hidden states
-            # hidden_states = torch.nested_tensor(hidden_states)
+            lengths = torch.sum(attention_mask, 1)
+            hidden_states = torch.nested_tensor(
+                [t[:l] for (t, l) in zip(hidden_states, lengths)],
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            attention_mask = None
         hidden_states = self.encoder(src=hidden_states, src_key_padding_mask=attention_mask)
 
         if not return_dict:

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -649,7 +649,9 @@ class BertFastEncoder(nn.Module):
 
         if attention_mask is not None:
             attention_mask = ~attention_mask.bool()
-            attention_mask = torch.squeeze(attention_mask)
+            attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
+            # remove padding from hidden states
+            # hidden_states = torch.nested_tensor(hidden_states)
         hidden_states = self.encoder(src=hidden_states, src_key_padding_mask=attention_mask)
 
         if not return_dict:

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -648,7 +648,7 @@ class BertFastEncoder(nn.Module):
         all_self_attentions = () if output_attentions else None
 
         if attention_mask is not None:
-            attention_mask = ~attention_mask.bool()
+            attention_mask = attention_mask.bool()
             attention_mask = torch.reshape(attention_mask, (attention_mask.shape[0], attention_mask.shape[-1]))
             lengths = torch.sum(attention_mask, 1)
             hidden_states = torch.nested_tensor(

--- a/src/transformers/models/distilbert/modeling_distilbert.py
+++ b/src/transformers/models/distilbert/modeling_distilbert.py
@@ -314,6 +314,75 @@ class Transformer(nn.Module):
         super().__init__()
         self.n_layers = config.n_layers
         self.layer = nn.ModuleList([TransformerBlock(config) for _ in range(config.n_layers)])
+        
+        # pulling from https://huggingface.co/distilbert-base-uncased/blob/main/config.json
+
+        # HF distilbert does not norm after all the encoder layers
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(
+                d_model=config.dim, 
+                nhead=config.n_heads, 
+                dim_feedforward=config.hidden_dim, 
+                dropout=config.dropout, 
+                activation=config.activation, # TODO make sure that this activation is supported 
+                layer_norm_eps=1e-12, # hardcoded in original distilbert  
+                batch_first=True, 
+                norm_first=False, # HF distilbert norms after
+                device=None, 
+                dtype=None), 
+            self.n_layers, 
+            norm=None) 
+        
+        self.from_hf(self) # for testing purposes 
+        del self.layer
+
+    def from_hf(self, hf_transformer):
+        for src_layer, dst_layer in zip(
+            hf_transformer.layer, self.encoder.layers
+        ):
+            # TODO make sure this doesn't use too much memory
+            in_proj_weight = torch.cat(
+                [
+                    src_layer.attention.q_lin.weight,
+                    src_layer.attention.k_lin.weight,
+                    src_layer.attention.v_lin.weight,
+                ],
+                dim=0
+            )
+            in_proj_bias = torch.cat(
+                [
+                    src_layer.attention.q_lin.bias,
+                    src_layer.attention.k_lin.bias,
+                    src_layer.attention.v_lin.bias,
+                ],
+                dim=0
+            )
+
+            dst_layer.self_attn.in_proj_weight = nn.Parameter(in_proj_weight)
+            dst_layer.self_attn.in_proj_bias = nn.Parameter(in_proj_bias)
+
+            dst_layer.self_attn.out_proj.weight = (
+                src_layer.attention.out_lin.weight
+            )
+            dst_layer.self_attn.out_proj.bias = (
+                src_layer.attention.out_lin.bias
+            )
+
+            dst_layer.linear1.weight = src_layer.ffn.lin1.weight
+            dst_layer.linear1.bias = src_layer.ffn.lin1.bias
+            # TODO make sure load in the same activation (given at src_layer.ffn.activation)
+
+            # this is fine because they're both nn.LayerNorm
+            dst_layer.norm1.load_state_dict(
+                src_layer.sa_layer_norm.state_dict()
+            )
+
+            dst_layer.linear2.weight = src_layer.ffn.lin2.weight
+            dst_layer.linear2.bias = src_layer.ffn.lin2.bias
+
+            dst_layer.norm2.load_state_dict(
+                src_layer.output_layer_norm.state_dict()
+            )
 
     def forward(
         self,
@@ -338,29 +407,16 @@ class Transformer(nn.Module):
                 Tuple of length n_layers with the attention weights from each layer
                 Optional: only if output_attentions=True
         """
-        all_hidden_states = () if output_hidden_states else None
-        all_attentions = () if output_attentions else None
-
-        hidden_state = x
-        for i, layer_module in enumerate(self.layer):
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_state,)
-
-            layer_outputs = layer_module(
-                x=hidden_state, attn_mask=attn_mask, head_mask=head_mask[i], output_attentions=output_attentions
-            )
-            hidden_state = layer_outputs[-1]
-
-            if output_attentions:
-                assert len(layer_outputs) == 2
-                attentions = layer_outputs[0]
-                all_attentions = all_attentions + (attentions,)
-            else:
-                assert len(layer_outputs) == 1
-
-        # Add last layer
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_state,)
+        # if(head_mask is not None):
+        #     raise Exception("Does not support head mask arg")
+        # if(output_attentions):
+        #     raise Exception("Does not support outputting attentions")
+        # if(output_hidden_states):
+        #     raise Exception("Does not support outputting all hidden states")
+        attn_mask = ~attn_mask.bool()
+        hidden_state = self.encoder(src=x, src_key_padding_mask=attn_mask)
+        all_hidden_states = None
+        all_attentions = None
 
         if not return_dict:
             return tuple(v for v in [hidden_state, all_hidden_states, all_attentions] if v is not None)


### PR DESCRIPTION
Steps to use the benchmark:

1. Install PyTorch nightly to get access to the fast path of nn.TransformerEncoder.
`pip3 install --pre torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/nightly/cu113`

2. Install this version of HF transformers by cloning this branch and running this cmd from the transformers dir
`pip install -e .`

3. Navigate to benchmark_bettertransformer.py and run `python3 benchmark_bettertransformer.py`